### PR TITLE
Generalize IdentifierExpressionAst to represent types and functions

### DIFF
--- a/sleepy/ast.py
+++ b/sleepy/ast.py
@@ -423,7 +423,7 @@ class FunctionDeclarationAst(StatementAst):
       if not isinstance(func_symbol, FunctionSymbol):
         self.raise_error('Cannot redefine previously declared non-function %r with a function' % self.identifier)
     else:
-      func_symbol = FunctionSymbol(returns_void=(return_type == SLEEPY_VOID))
+      func_symbol = FunctionSymbol(identifier=self.identifier, returns_void=(return_type == SLEEPY_VOID))
       symbol_table[self.identifier] = func_symbol
       func_symbol_table[self.identifier] = func_symbol
     if func_symbol in {symbol_table.inbuilt_symbols.get(name) for name in {'assert', 'unchecked_assert'}}:

--- a/sleepy/ast.py
+++ b/sleepy/ast.py
@@ -11,7 +11,7 @@ from sleepy.symbols import FunctionSymbol, VariableSymbol, Type, SLEEPY_VOID, SL
   TypeSymbol, \
   StructType, ConcreteFunction, UnionType, can_implicit_cast_to, \
   make_implicit_cast_to_ir_val, make_ir_val_is_type, build_initial_ir, CodegenContext, get_common_type, \
-  SLEEPY_CHAR_PTR, FunctionSignature, TemplateType, ConcreteFunctionFactory, TypeFactory, try_infer_templ_types
+  SLEEPY_CHAR_PTR, FunctionSignature, TemplateType, ConcreteFunctionFactory, TypeFactory, try_infer_templ_types, Symbol
 
 SLOPPY_OP_TYPES = {'*', '/', '+', '-', '==', '!=', '<', '>', '<=', '>', '>=', 'is', '='}
 from abc import ABC, abstractmethod
@@ -44,9 +44,9 @@ class AbstractSyntaxTree(ABC):
     """
     raise SemanticError(self.pos.word, self.pos.from_pos, self.pos.to_pos, message)
 
-  def resolve_func_call(self, func_identifier: str, templ_types: Optional[List[Type]],
-                        func_arg_exprs: List[ExpressionAst],
-                        symbol_table: SymbolTable) -> Tuple[FunctionSymbol, List[ConcreteFunction]]:
+  def resolve_func_call_by_identifier(self, func_identifier: str, templ_types: Optional[List[Type]],
+                                      func_arg_exprs: List[ExpressionAst],
+                                      symbol_table: SymbolTable) -> List[ConcreteFunction]:
     if func_identifier not in symbol_table:
       self.raise_error('Function %r called before declared' % func_identifier)
     symbol = symbol_table[func_identifier]
@@ -58,27 +58,32 @@ class AbstractSyntaxTree(ABC):
       assert isinstance(symbol, FunctionSymbol)
     if not isinstance(symbol, FunctionSymbol):
       self.raise_error('Cannot call non-function %r' % func_identifier)
+    return self.resolve_func_call(
+      func=symbol, templ_types=templ_types, func_arg_exprs=func_arg_exprs, symbol_table=symbol_table)
+
+  def resolve_func_call(self, func: Union[FunctionSymbol, TypeSymbol], templ_types: Optional[List[Type]],
+                        func_arg_exprs: List[ExpressionAst],
+                        symbol_table: SymbolTable) -> List[ConcreteFunction]:
     calling_types = [arg_expr.make_val_type(symbol_table=symbol_table) for arg_expr in func_arg_exprs]
 
     if templ_types is None:
-      templ_types = self._infer_templ_args(
-        func_identifier=func_identifier, func_symbol=symbol, calling_types=calling_types)
+      templ_types = self._infer_templ_args(func=func, calling_types=calling_types)
     assert templ_types is not None
     assert all(not templ_type.has_templ_placeholder() for templ_type in templ_types)
 
-    if not symbol.can_call_with_arg_types(concrete_templ_types=templ_types, arg_types=calling_types):
-      symbol.can_call_with_arg_types(concrete_templ_types=templ_types, arg_types=calling_types)
+    if not func.can_call_with_arg_types(concrete_templ_types=templ_types, arg_types=calling_types):
+      func.can_call_with_arg_types(concrete_templ_types=templ_types, arg_types=calling_types)
       self.raise_error(
         'Cannot call function %r with arguments of types %r and template parameters %r, '
         'only declared for parameter types:\n%s' % (
-          func_identifier, ', '.join([str(calling_type) for calling_type in calling_types]),
+          func.identifier, ', '.join([str(calling_type) for calling_type in calling_types]),
           ', '.join([str(templ_type) for templ_type in templ_types]),
-          symbol.make_signature_list_str()))
+          func.make_signature_list_str()))
     if not all(called_type.is_realizable() for called_type in calling_types):
       self.raise_error('Cannot call function %r with argument of types %r which are unrealizable' % (
-        func_identifier, ', '.join([str(called_type) for called_type in calling_types])))
+        func.identifier, ', '.join([str(called_type) for called_type in calling_types])))
 
-    possible_concrete_funcs = symbol.get_concrete_funcs(templ_types=templ_types, arg_types=calling_types)
+    possible_concrete_funcs = func.get_concrete_funcs(templ_types=templ_types, arg_types=calling_types)
     assert len(possible_concrete_funcs) >= 1
     for concrete_func in possible_concrete_funcs:
       called_mutables = [arg_expr.is_val_mutable(symbol_table=symbol_table) for arg_expr in func_arg_exprs]
@@ -86,11 +91,10 @@ class AbstractSyntaxTree(ABC):
           concrete_func.arg_identifiers, concrete_func.arg_mutables, called_mutables):
         if not called_mutable and arg_mutable:
           self.raise_error('Cannot call function %s%s declared with mutable parameter %r with immutable argument' % (
-              func_identifier, concrete_func.signature.to_signature_str(), arg_identifier))
-    return symbol, possible_concrete_funcs
+              func.identifier, concrete_func.signature.to_signature_str(), arg_identifier))
+    return possible_concrete_funcs
 
-  def _infer_templ_args(self, func_identifier: str, func_symbol: FunctionSymbol,
-                        calling_types: List[Type]) -> List[Type]:
+  def _infer_templ_args(self, func: FunctionSymbol, calling_types: List[Type]) -> List[Type]:
     # TODO: We currently require that the template types must be statically determinable.
     # e.g. assume that our function takes a union argument.
     # If we have overloaded signatures each with template arguments, it can happen that you should use different
@@ -99,25 +103,25 @@ class AbstractSyntaxTree(ABC):
     # Note that that would make function calls with inferred template types more than just an auto-evaluated type arg.
     assert all(calling_type.is_realizable() for calling_type in calling_types)
     signature_templ_types = None
-    for expanded_calling_types in func_symbol.iter_expanded_possible_arg_types(calling_types):
+    for expanded_calling_types in func.iter_expanded_possible_arg_types(calling_types):
       infers = [
         try_infer_templ_types(
           calling_types=expanded_calling_types, signature_types=signature.arg_types,
           placeholder_templ_types=signature.placeholder_templ_types)
-        for signature in func_symbol.signatures]
+        for signature in func.signatures]
       possible_infers = [idx for idx, infer in enumerate(infers) if infer is not None]
       if len(possible_infers) == 0:
         self.raise_error(
           'Cannot infer template types for function %r from arguments of types %r, '
           'is declared for parameter types:\n%s' % (
-            func_identifier, ', '.join([str(calling_type) for calling_type in calling_types]),
-            func_symbol.make_signature_list_str()))
+            func.identifier, ', '.join([str(calling_type) for calling_type in calling_types]),
+            func.make_signature_list_str()))
       if len(possible_infers) > 1:
         self.raise_error(
           'Cannot uniquely infer template types for function %r from arguments of types %r, '
           'is declared for parameter types:\n%s' % (
-            func_identifier, ', '.join([str(calling_type) for calling_type in calling_types]),
-            func_symbol.make_signature_list_str()))
+            func.identifier, ', '.join([str(calling_type) for calling_type in calling_types]),
+            func.make_signature_list_str()))
       assert len(possible_infers) == 1
       expanded_signature_templ_types = infers[possible_infers[0]]
       assert expanded_signature_templ_types is not None
@@ -126,22 +130,20 @@ class AbstractSyntaxTree(ABC):
           'Cannot uniquely statically infer template types for function %r from arguments of types %r '
           'because different expanded union types would require different template types. '
           'Function is declared for parameter types:\n%s' % (
-            func_identifier, ', '.join([str(calling_type) for calling_type in calling_types]),
-            func_symbol.make_signature_list_str()))
+            func.identifier, ', '.join([str(calling_type) for calling_type in calling_types]),
+            func.make_signature_list_str()))
       signature_templ_types = expanded_signature_templ_types
     assert signature_templ_types is not None
     return signature_templ_types
 
-  def _build_func_call(self, func_identifier: str, templ_types: Optional[List[Type]],
+  def _build_func_call(self, func: FunctionSymbol, templ_types: Optional[List[Type]],
                        func_arg_exprs: List[ExpressionAst], symbol_table: SymbolTable, context: CodegenContext):
-    symbol, possible_concrete_funcs = self.resolve_func_call(
-      func_identifier=func_identifier, templ_types=templ_types, func_arg_exprs=func_arg_exprs,
-      symbol_table=symbol_table)
+    possible_concrete_funcs = self.resolve_func_call(
+      func=func, templ_types=templ_types, func_arg_exprs=func_arg_exprs, symbol_table=symbol_table)
     calling_types = [arg_expr.make_val_type(symbol_table=symbol_table) for arg_expr in func_arg_exprs]
 
     if templ_types is None:
-      templ_types = self._infer_templ_args(
-        func_identifier=func_identifier, func_symbol=symbol, calling_types=calling_types)
+      templ_types = self._infer_templ_args(func=func, calling_types=calling_types)
     assert templ_types is not None
 
     for concrete_func in possible_concrete_funcs:
@@ -155,8 +157,8 @@ class AbstractSyntaxTree(ABC):
         func_arg_expr.make_ir_val(symbol_table=symbol_table, context=context) for func_arg_expr in func_arg_exprs]
       from sleepy.symbols import make_func_call_ir
       return_ir_val = make_func_call_ir(
-        func_identifier=func_identifier, func_symbol=symbol, templ_types=templ_types, calling_arg_types=calling_types,
-        calling_ir_args=ir_func_args, context=context)
+        func=func, templ_types=templ_types, calling_arg_types=calling_types, calling_ir_args=ir_func_args,
+        context=context)
     else:
       return_ir_val = None
 
@@ -164,13 +166,13 @@ class AbstractSyntaxTree(ABC):
     for arg_num, func_arg_expr in enumerate(func_arg_exprs):
       narrowed_arg_types = [concrete_func.arg_type_narrowings[arg_num] for concrete_func in possible_concrete_funcs]
       narrowed_arg_type = get_common_type(narrowed_arg_types)
-      if isinstance(func_arg_expr, VariableExpressionAst):
-        var_symbol = symbol_table[func_arg_expr.var_identifier]
+      if isinstance(func_arg_expr, IdentifierExpressionAst):
+        var_symbol = symbol_table[func_arg_expr.identifier]
         assert isinstance(var_symbol, VariableSymbol)
-        symbol_table[func_arg_expr.var_identifier] = var_symbol.copy_narrow_type(narrowed_arg_type)
+        symbol_table[func_arg_expr.identifier] = var_symbol.copy_narrow_type(narrowed_arg_type)
 
     # special handling of 'assert' call
-    if symbol.base in {symbol_table.inbuilt_symbols.get(identifier) for identifier in {'assert', 'unchecked_assert'}}:
+    if func.base in {symbol_table.inbuilt_symbols.get(identifier) for identifier in {'assert', 'unchecked_assert'}}:
       assert len(func_arg_exprs) >= 1
       condition_expr = func_arg_exprs[0]
       make_narrow_type_from_valid_cond_ast(condition_expr, cond_holds=True, symbol_table=symbol_table)
@@ -773,9 +775,9 @@ class AssignStatementAst(StatementAst):
     :param SymbolTable symbol_table:
     :rtype: bool
     """
-    if not isinstance(self.var_target, VariableExpressionAst):
+    if not isinstance(self.var_target, IdentifierExpressionAst):
       return False
-    var_identifier = self.var_target.var_identifier
+    var_identifier = self.var_target.identifier
     if var_identifier not in symbol_table.current_scope_identifiers:
       return True
     assert var_identifier in symbol_table
@@ -807,8 +809,8 @@ class AssignStatementAst(StatementAst):
       val_mutable = self.var_val.is_val_mutable(symbol_table=symbol_table)
 
       if self.is_declaration(symbol_table=symbol_table):
-        assert isinstance(self.var_target, VariableExpressionAst)
-        var_identifier = self.var_target.var_identifier
+        assert isinstance(self.var_target, IdentifierExpressionAst)
+        var_identifier = self.var_target.identifier
         assert var_identifier not in symbol_table.current_scope_identifiers
         if stated_type is not None:
           declared_type = stated_type
@@ -844,13 +846,13 @@ class AssignStatementAst(StatementAst):
       assert self.var_target.is_val_assignable(symbol_table=symbol_table)
 
       # if we assign to a variable, narrow type to val_type
-      if isinstance(self.var_target, VariableExpressionAst):
-        assert self.var_target.var_identifier in symbol_table
-        symbol = symbol_table[self.var_target.var_identifier]
+      if isinstance(self.var_target, IdentifierExpressionAst):
+        assert self.var_target.identifier in symbol_table
+        symbol = symbol_table[self.var_target.identifier]
         assert isinstance(symbol, VariableSymbol)
         narrowed_symbol = symbol.copy_with_narrowed_type(val_type)
         assert not isinstance(narrowed_symbol, UnionType) or len(narrowed_symbol.possible_types) > 0
-        symbol_table[self.var_target.var_identifier] = narrowed_symbol
+        symbol_table[self.var_target.identifier] = narrowed_symbol
 
       if context.emits_ir:
         ir_val = self.var_val.make_ir_val(symbol_table=symbol_table, context=context)
@@ -1009,43 +1011,25 @@ class ExpressionAst(AbstractSyntaxTree, ABC):
   """
   Val, SumVal, ProdVal, PrimaryExpr
   """
-  def __init__(self, pos):
-    """
-    :param TreePosition pos:
-    """
+  def __init__(self, pos: TreePosition):
     super().__init__(pos)
 
-  def make_val_type(self, symbol_table):
-    """
-    :param SymbolTable symbol_table:
-    :rtype: Type
-    """
+  @abstractmethod
+  def make_val_type(self, symbol_table: SymbolTable) -> Type:
     raise NotImplementedError()
 
-  def make_declared_val_type(self, symbol_table):
-    """
-    :param SymbolTable symbol_table:
-    :rtype: Type
-    """
+  def make_declared_val_type(self, symbol_table: SymbolTable) -> Type:
     if self.is_val_mutable(symbol_table=symbol_table) or self.is_val_assignable(symbol_table=symbol_table):
       raise NotImplementedError()
     return self.make_val_type(symbol_table=symbol_table)
 
-  def is_val_mutable(self, symbol_table):
-    """
-    :param SymbolTable symbol_table:
-    :rtype: Type
-    """
+  def is_val_mutable(self, symbol_table: SymbolTable) -> bool:
     return False
 
-  def is_val_assignable(self, symbol_table):
-    """
-    :param SymbolTable symbol_table:
-    :rtype bool:
-    """
+  def is_val_assignable(self, symbol_table: SymbolTable) -> bool:
     return False
 
-  def make_ir_val(self, symbol_table, context):
+  def make_ir_val(self, symbol_table: SymbolTable, context: CodegenContext) -> Optional[ir.values.Value]:
     """
     :param SymbolTable symbol_table:
     :param CodegenContext context:
@@ -1055,21 +1039,17 @@ class ExpressionAst(AbstractSyntaxTree, ABC):
     assert context.emits_ir
     raise NotImplementedError()
 
-  def make_ir_val_ptr(self, symbol_table, context):
-    """
-    :param SymbolTable symbol_table:
-    :param CodegenContext context:
-    :rtype: ir.instructions.Instruction|None
-    """
+  def make_ir_val_ptr(self, symbol_table: SymbolTable,
+                      context: CodegenContext) -> Optional[ir.instructions.Instruction]:
     assert context.emits_ir
     if self.is_val_mutable(symbol_table=symbol_table) or self.is_val_assignable(symbol_table=symbol_table):
       raise NotImplementedError()
     return None
 
-  def __repr__(self):
-    """
-    :rtype: str
-    """
+  def make_func(self, symbol_table: SymbolTable) -> Optional[FunctionSymbol]:
+    return None
+
+  def __repr__(self) -> str:
     return 'ExpressionAst'
 
 
@@ -1091,7 +1071,7 @@ class BinaryOperatorExpressionAst(ExpressionAst):
     if self.op == 'is':
       # TODO: Then it should be a TypeExpressionAst, not a VariableExpressionAst.
       # Probably it's nicer to make an entire new ExpressionAst for `is` Expressions anyway.
-      if not isinstance(self.right_expr, VariableExpressionAst):
+      if not isinstance(self.right_expr, IdentifierExpressionAst):
         raise self.raise_error("'is' operator must be applied to a union type and a type.")
 
   def make_val_type(self, symbol_table):
@@ -1100,13 +1080,13 @@ class BinaryOperatorExpressionAst(ExpressionAst):
     :rtype: Type
     """
     if self.op == 'is':
-      assert isinstance(self.right_expr, VariableExpressionAst)
+      assert isinstance(self.right_expr, IdentifierExpressionAst)
       type_expr = IdentifierTypeAst(
-        self.right_expr.pos, type_identifier=self.right_expr.var_identifier, templ_types=[])
+        self.right_expr.pos, type_identifier=self.right_expr.identifier, templ_types=[])
       type_expr.make_type(symbol_table=symbol_table)  # just check that type exists
       return SLEEPY_BOOL
     operand_exprs = [self.left_expr, self.right_expr]
-    _, possible_concrete_funcs = self.resolve_func_call(
+    possible_concrete_funcs = self.resolve_func_call_by_identifier(
       func_identifier=self.op, templ_types=None, func_arg_exprs=operand_exprs, symbol_table=symbol_table)
     return get_common_type([concrete_func.return_type for concrete_func in possible_concrete_funcs])
 
@@ -1118,7 +1098,7 @@ class BinaryOperatorExpressionAst(ExpressionAst):
     if self.op == 'is':
       return False
     operand_exprs = [self.left_expr, self.right_expr]
-    _, possible_concrete_funcs = self.resolve_func_call(
+    possible_concrete_funcs = self.resolve_func_call_by_identifier(
       func_identifier=self.op, templ_types=None, func_arg_exprs=operand_exprs, symbol_table=symbol_table)
     return all(concrete_func.return_mutable for concrete_func in possible_concrete_funcs)
 
@@ -1131,16 +1111,18 @@ class BinaryOperatorExpressionAst(ExpressionAst):
     with context.use_pos(self.pos):
       assert context.emits_ir
       if self.op == 'is':
-        assert isinstance(self.right_expr, VariableExpressionAst)
+        assert isinstance(self.right_expr, IdentifierExpressionAst)
         check_type_expr = IdentifierTypeAst(
-          self.right_expr.pos, type_identifier=self.right_expr.var_identifier, templ_types=[])
+          self.right_expr.pos, type_identifier=self.right_expr.identifier, templ_types=[])
         check_type = check_type_expr.make_type(symbol_table=symbol_table)
         val_type = self.left_expr.make_val_type(symbol_table=symbol_table)
         ir_val = self.left_expr.make_ir_val(symbol_table=symbol_table, context=context)
         return make_ir_val_is_type(ir_val, val_type, check_type, context=context)
+      func = symbol_table[self.op]
+      assert isinstance(func, FunctionSymbol)
       operand_exprs = [self.left_expr, self.right_expr]
       return_val = self._build_func_call(
-        func_identifier=self.op, templ_types=None, func_arg_exprs=operand_exprs, symbol_table=symbol_table,
+        func=func, templ_types=None, func_arg_exprs=operand_exprs, symbol_table=symbol_table,
         context=context)
       assert return_val is not None
       return return_val
@@ -1176,7 +1158,7 @@ class UnaryOperatorExpressionAst(ExpressionAst):
     :rtype: Type
     """
     operand_exprs = [self.expr]
-    _, possible_concrete_funcs = self.resolve_func_call(
+    possible_concrete_funcs = self.resolve_func_call_by_identifier(
       func_identifier=self.op, templ_types=None, func_arg_exprs=operand_exprs, symbol_table=symbol_table)
     return get_common_type([concrete_func.return_type for concrete_func in possible_concrete_funcs])
 
@@ -1186,7 +1168,7 @@ class UnaryOperatorExpressionAst(ExpressionAst):
     :rtype: Type
     """
     operand_exprs = [self.expr]
-    _, possible_concrete_funcs = self.resolve_func_call(
+    possible_concrete_funcs = self.resolve_func_call_by_identifier(
       func_identifier=self.op, templ_types=None, func_arg_exprs=operand_exprs, symbol_table=symbol_table)
     return all(concrete_func.return_mutable for concrete_func in possible_concrete_funcs)
 
@@ -1198,9 +1180,11 @@ class UnaryOperatorExpressionAst(ExpressionAst):
     """
     with context.use_pos(self.pos):
       assert context.emits_ir
+      func = symbol_table[self.op]
+      assert isinstance(func, FunctionSymbol)
       operand_exprs = [self.expr]
       return self._build_func_call(
-        func_identifier=self.op, templ_types=None, func_arg_exprs=operand_exprs, symbol_table=symbol_table,
+        func=func, templ_types=None, func_arg_exprs=operand_exprs, symbol_table=symbol_table,
         context=context)
 
   def children(self) -> List[AbstractSyntaxTree]:
@@ -1333,85 +1317,70 @@ class StringLiteralExpressionAst(ExpressionAst):
     return 'StringLiteralExpressionAst(constant_str=%r)' % self.constant_str
 
 
-class VariableExpressionAst(ExpressionAst):
+class IdentifierExpressionAst(ExpressionAst):
   """
   PrimaryExpr -> identifier
   """
-  def __init__(self, pos, var_identifier):
+  def __init__(self, pos, identifier):
     """
     :param TreePosition pos:
-    :param str var_identifier:
+    :param str identifier:
     """
     super().__init__(pos)
-    self.var_identifier = var_identifier
+    self.identifier = identifier
 
-  def get_var_symbol(self, symbol_table):
-    """
-    :param SymbolTable symbol_table:
-    :rtype: VariableSymbol
-    """
-    if self.var_identifier not in symbol_table:
-      self.raise_error('Variable %r referenced before declaring' % self.var_identifier)
-    symbol = symbol_table[self.var_identifier]
-    if not isinstance(symbol, VariableSymbol):
-      self.raise_error('Cannot reference a non-variable %r, got a %s' % (self.var_identifier, type(symbol).__name__))
-    if self.var_identifier not in symbol_table.current_scope_identifiers:
-      # TODO add variable captures
-      self.raise_error('Cannot capture variable %r from outer scope' % self.var_identifier)
+  def get_symbol(self, symbol_table: SymbolTable) -> Symbol:
+    if self.identifier not in symbol_table:
+      self.raise_error('Identifier %r referenced before declaring' % self.identifier)
+    symbol = symbol_table[self.identifier]
     return symbol
 
-  def make_val_type(self, symbol_table):
-    """
-    :param SymbolTable symbol_table:
-    :rtype: Type
-    """
+  def get_var_symbol(self, symbol_table: SymbolTable) -> VariableSymbol:
+    symbol = self.get_symbol(symbol_table=symbol_table)
+    if not isinstance(symbol, VariableSymbol):
+      self.raise_error('Cannot reference a non-variable %r, got a %s' % (self.identifier, symbol.kind))
+    if self.identifier not in symbol_table.current_scope_identifiers:
+      # TODO add variable captures
+      self.raise_error('Cannot capture variable %r from outer scope' % self.identifier)
+    return symbol
+
+  def get_func_symbol(self, symbol_table: SymbolTable) -> FunctionSymbol:
+    symbol = self.get_symbol(symbol_table=symbol_table)
+    if isinstance(symbol, TypeSymbol):
+      if symbol.constructor_symbol is None:
+        self.raise_error('Cannot reference non existing constructor of type %r' % self.identifier)
+      symbol = symbol.constructor_symbol
+    if not isinstance(symbol, FunctionSymbol):
+      self.raise_error('Cannot reference a non-function %r, got a %s' % (self.identifier, symbol.kind))
+    return symbol
+
+  def make_val_type(self, symbol_table: SymbolTable) -> Type:
     return self.get_var_symbol(symbol_table=symbol_table).narrowed_var_type
 
-  def make_declared_val_type(self, symbol_table):
-    """
-    :param SymbolTable symbol_table:
-    :rtype: Type
-    """
+  def make_declared_val_type(self, symbol_table: SymbolTable) -> Type:
     return self.get_var_symbol(symbol_table=symbol_table).declared_var_type
 
-  def is_val_mutable(self, symbol_table):
-    """
-    :param SymbolTable symbol_table:
-    :rtype: Type
-    """
+  def is_val_mutable(self, symbol_table: SymbolTable) -> bool:
     return self.get_var_symbol(symbol_table=symbol_table).mutable
 
-  def is_val_assignable(self, symbol_table):
-    """
-    :param SymbolTable symbol_table:
-    :rtype: bool
-    """
+  def is_val_assignable(self, symbol_table: SymbolTable) -> bool:
     return True
 
-  def make_ir_val(self, symbol_table, context):
-    """
-    :param SymbolTable symbol_table:
-    :param CodegenContext context:
-    :rtype: ir.values.Value
-    """
+  def make_ir_val(self, symbol_table: SymbolTable, context: CodegenContext) -> ir.values.Value:
     with context.use_pos(self.pos):
       assert context.emits_ir
       symbol = self.get_var_symbol(symbol_table=symbol_table)
-      return context.builder.load(symbol.ir_alloca, name=self.var_identifier)
+      return context.builder.load(symbol.ir_alloca, name=self.identifier)
 
-  def make_ir_val_ptr(self, symbol_table, context):
-    """
-    :param SymbolTable symbol_table:
-    :param CodegenContext context:
-    :rtype: ir.instructions.Instruction
-    """
+  def make_ir_val_ptr(self, symbol_table: SymbolTable, context: CodegenContext) -> ir.instructions.Instruction:
     with context.use_pos(self.pos):
       assert context.emits_ir
-      assert self.var_identifier in symbol_table
-      symbol = symbol_table[self.var_identifier]
-      assert isinstance(symbol, VariableSymbol)
+      symbol = self.get_var_symbol(symbol_table=symbol_table)
       assert symbol.ir_alloca is not None
       return symbol.ir_alloca
+
+  def make_func(self, symbol_table: SymbolTable) -> FunctionSymbol:
+    return self.get_func_symbol(symbol_table=symbol_table)
 
   def children(self) -> List[AbstractSyntaxTree]:
     return []
@@ -1420,43 +1389,25 @@ class VariableExpressionAst(ExpressionAst):
     """
     :rtype: str
     """
-    return 'VariableExpressionAst(var_identifier=%r)' % self.var_identifier
+    return 'VariableExpressionAst(var_identifier=%r)' % self.identifier
 
 
 class CallExpressionAst(ExpressionAst):
   """
   PrimaryExpr -> identifier ( ExprList )
   """
-  def __init__(self, pos, func_identifier, func_arg_exprs):
-    """
-    :param TreePosition pos:
-    :param str func_identifier:
-    :param list[ExpressionAst] func_arg_exprs:
-    """
+  def __init__(self, pos: TreePosition, func_expr: ExpressionAst, func_arg_exprs: List[ExpressionAst]):
     super().__init__(pos)
-    self.func_identifier = func_identifier
+    self.func_expr = func_expr
     self.func_arg_exprs = func_arg_exprs
-
-  def get_func_symbol(self, symbol_table):
-    """
-    :param SymbolTable symbol_table:
-    :rtype: FunctionSymbol
-    """
-    assert self.func_identifier in symbol_table
-    symbol = symbol_table[self.func_identifier]
-    if isinstance(symbol, TypeSymbol):
-      symbol = symbol.constructor_symbol
-    assert isinstance(symbol, FunctionSymbol)
-    assert symbol is not None
-    return symbol
 
   def make_val_type(self, symbol_table):
     """
     :param SymbolTable symbol_table:
     :rtype: Type
     """
-    _, possible_concrete_funcs = self.resolve_func_call(
-      func_identifier=self.func_identifier, templ_types=None, func_arg_exprs=self.func_arg_exprs,
+    possible_concrete_funcs = self.resolve_func_call(
+      func=self.func_expr.make_func(symbol_table=symbol_table), templ_types=None, func_arg_exprs=self.func_arg_exprs,
       symbol_table=symbol_table)
     return get_common_type([concrete_func.return_type for concrete_func in possible_concrete_funcs])
 
@@ -1465,8 +1416,8 @@ class CallExpressionAst(ExpressionAst):
     :param SymbolTable symbol_table:
     :rtype: Type
     """
-    _, possible_concrete_funcs = self.resolve_func_call(
-      func_identifier=self.func_identifier, templ_types=None, func_arg_exprs=self.func_arg_exprs,
+    possible_concrete_funcs = self.resolve_func_call(
+      func=self.func_expr.make_func(symbol_table=symbol_table), templ_types=None, func_arg_exprs=self.func_arg_exprs,
       symbol_table=symbol_table)
     return all(concrete_func.return_mutable for concrete_func in possible_concrete_funcs)
 
@@ -1479,7 +1430,7 @@ class CallExpressionAst(ExpressionAst):
     with context.use_pos(self.pos):
       assert context.emits_ir
       return self._build_func_call(
-        func_identifier=self.func_identifier, templ_types=None, func_arg_exprs=self.func_arg_exprs,
+        func=self.func_expr.make_func(symbol_table=symbol_table), templ_types=None, func_arg_exprs=self.func_arg_exprs,
         symbol_table=symbol_table, context=context)
 
   def children(self) -> List[AbstractSyntaxTree]:
@@ -1489,7 +1440,7 @@ class CallExpressionAst(ExpressionAst):
     """
     :rtype: str
     """
-    return 'CallExpressionAst(func_identifier=%r, func_arg_exprs=%r)' % (self.func_identifier, self.func_arg_exprs)
+    return 'CallExpressionAst(func_expr=%r, func_arg_exprs=%r)' % (self.func_expr, self.func_arg_exprs)
 
 
 class MemberExpressionAst(ExpressionAst):
@@ -1719,14 +1670,14 @@ def make_narrow_type_from_valid_cond_ast(cond_expr_ast, cond_holds, symbol_table
   # TODO: This is super limited currently: Will only work for if(local_var is Type), nothing more.
   if isinstance(cond_expr_ast, BinaryOperatorExpressionAst) and cond_expr_ast.op == 'is':
     var_expr = cond_expr_ast.left_expr
-    if not isinstance(var_expr, VariableExpressionAst):
+    if not isinstance(var_expr, IdentifierExpressionAst):
       return
     var_symbol = var_expr.get_var_symbol(symbol_table=symbol_table)
-    assert isinstance(cond_expr_ast.right_expr, VariableExpressionAst)
+    assert isinstance(cond_expr_ast.right_expr, IdentifierExpressionAst)
     check_type_expr = IdentifierTypeAst(
-      cond_expr_ast.right_expr.pos, cond_expr_ast.right_expr.var_identifier, templ_types=[])
+      cond_expr_ast.right_expr.pos, cond_expr_ast.right_expr.identifier, templ_types=[])
     check_type = check_type_expr.make_type(symbol_table=symbol_table)
     if cond_holds:
-      symbol_table[var_expr.var_identifier] = var_symbol.copy_narrow_type(check_type)
+      symbol_table[var_expr.identifier] = var_symbol.copy_narrow_type(check_type)
     else:
-      symbol_table[var_expr.var_identifier] = var_symbol.copy_exclude_type(check_type)
+      symbol_table[var_expr.identifier] = var_symbol.copy_exclude_type(check_type)

--- a/sleepy/ast.py
+++ b/sleepy/ast.py
@@ -11,7 +11,7 @@ from sleepy.symbols import FunctionSymbol, VariableSymbol, Type, SLEEPY_VOID, SL
   TypeSymbol, \
   StructType, ConcreteFunction, UnionType, can_implicit_cast_to, \
   make_implicit_cast_to_ir_val, make_ir_val_is_type, build_initial_ir, CodegenContext, get_common_type, \
-  SLEEPY_CHAR_PTR, FunctionSignature, TemplateType, ConcreteFunctionFactory, TypeFactory, try_infer_templ_types, Symbol, \
+  SLEEPY_CHAR_PTR, FunctionTemplate, TemplateType, ConcreteFunctionFactory, TypeFactory, try_infer_templ_types, Symbol, \
   FunctionSymbolCaller
 
 SLOPPY_OP_TYPES = {'*', '/', '+', '-', '==', '!=', '<', '>', '<=', '>', '>=', 'is', '='}
@@ -518,7 +518,7 @@ class FunctionDeclarationAst(StatementAst):
               ir_func_args=concrete_func.ir_func.args)
 
     concrete_func_factory = DeclaredConcreteFunctionFactory()
-    signature_ = FunctionSignature(
+    signature_ = FunctionTemplate(
       concrete_func_factory=concrete_func_factory, placeholder_templ_types=placeholder_templ_types,
       return_type=return_type, return_mutable=return_mutable, arg_identifiers=self.arg_identifiers,
       arg_types=arg_types, arg_mutables=arg_mutables, arg_type_narrowings=arg_types, is_inline=self.is_inline)

--- a/sleepy/symbols.py
+++ b/sleepy/symbols.py
@@ -23,15 +23,26 @@ class Symbol(ABC):
   """
   A declared symbol, with an identifier.
   """
+  kind = None
+
   def __init__(self):
     """
     Initialize the symbol.
     """
     self.base = self  # type: Symbol
+    assert self.kind is not None
 
   @abstractmethod
   def copy_replace_unbound_templ_types(self, templ_type_replacements: Dict[TemplateType, Type]) -> Symbol:
     raise NotImplementedError()
+
+  class Kind(Enum):
+    """
+    Possible symbol types.
+    """
+    VARIABLE = 'var'
+    TYPE = 'type'
+    FUNCTION = 'func'
 
 
 class Type(ABC):
@@ -1089,6 +1100,7 @@ class VariableSymbol(Symbol):
   """
   A declared variable.
   """
+  kind = Symbol.Kind.VARIABLE
 
   def __init__(self, ir_alloca: Optional[ir.instructions.AllocaInstr], var_type: Type, mutable: bool):
     super().__init__()
@@ -1370,6 +1382,8 @@ class FunctionSymbol(Symbol):
   Each of these signatures itself can have a set of concrete implementations,
   where template types have been replaced with concrete types.
   """
+  kind = Symbol.Kind.FUNCTION
+
   def __init__(self, identifier: str, returns_void: bool, base: Optional[FunctionSymbol] = None):
     super().__init__()
     self.identifier = identifier
@@ -1492,6 +1506,7 @@ class TypeSymbol(Symbol):
   Can have one or multiple template initializations that yield different concrete types.
   These are initialized lazily.
   """
+  kind = Symbol.Kind.TYPE
 
   def __init__(self, type_factory: TypeFactory, constructor_symbol: Optional[FunctionSymbol]):
     super().__init__()

--- a/tests/test_ast.py
+++ b/tests/test_ast.py
@@ -1875,6 +1875,21 @@ def test_templ_struct():
     assert_equal(main(23, 43), 23 + 43)
 
 
+def test_templ_explicit_types():
+  with make_execution_engine() as engine:
+    program = """
+    func noop[T](x: T) -> T {
+      return x;
+    }
+    func main(a: Int) -> Int {
+      b = noop[Int](a);
+      return b;
+    }
+    """
+    main = compile_program(engine, program, add_preamble=False)
+    assert_equal(main(3), 3)
+
+
 def test_ptr_loop():
   with make_execution_engine() as engine:
     program = """


### PR DESCRIPTION
This allows `foo[Types...](args...)`: Here, `foo` is a "Function", while all `Types...` are "Types". All are represented using `IdentifierExpressionAst`.
Added special handling s.t. the `[]` operator can be called on functions (here `foo`) and types (`Types...`). This sets concrete template parameters (similar to currying).
This function is then normally called with the `args...` which are just normal variables.

Internally, this is handled using `FunctionSymbolCaller`, which is a `FunctionSymbol` and optionally a list of template parameters.
First, I thought we could copy the generic function symbol with template arguments with the concrete template types, but this does not play nice with overloads: Copying an overloaded function with a partial amount of (template) parameters set is much more difficult then if there is only one (non-overloaded) function.