### PR TITLE
Imports

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -2,3 +2,5 @@ better_exchook
 nose~=1.3.7
 numpy
 llvmlite~=0.36.0
+
+networkx~=2.6.3

--- a/sleepy/ast.py
+++ b/sleepy/ast.py
@@ -252,19 +252,36 @@ class AbstractScopeAst(AbstractSyntaxTree):
 
 
 class FileAst(AbstractSyntaxTree):
-  """
-  TopLevelExpr.
-  """
-
-  def __init__(self, pos: TreePosition, stmt_list: List[StatementAst]):
+  def __init__(self, pos: TreePosition, stmt_list: List[StatementAst], imports_ast: ImportsAst):
     super().__init__(pos)
+    self.imports_ast = imports_ast
     self.stmt_list = stmt_list
 
   def children(self) -> List[AbstractSyntaxTree]:
-    return self.stmt_list
+    return [self.imports_ast] + self.stmt_list
 
   def __repr__(self) -> str:
     return 'TopLevelAst(%s)' % self.stmt_list
+
+class ImportsAst(AbstractSyntaxTree):
+  def __init__(self, pos: TreePosition, import_asts: List[ImportAst]):
+    super().__init__(pos)
+    self.import_asts = import_asts
+
+  @property
+  def imports(self) -> List[str]:
+    return [a.path for a in self.import_asts]
+
+  def children(self) -> List[AbstractSyntaxTree]:
+    return self.import_asts
+
+class ImportAst(AbstractSyntaxTree):
+  def __init__(self, pos: TreePosition, path: str):
+    super().__init__(pos)
+    self.path = path
+
+  def children(self) -> List[AbstractSyntaxTree]:
+    return []
 
 
 class TranslationUnitAst(AbstractSyntaxTree):

--- a/sleepy/ast.py
+++ b/sleepy/ast.py
@@ -252,10 +252,14 @@ class AbstractScopeAst(AbstractSyntaxTree):
 
 
 class FileAst(AbstractSyntaxTree):
-  def __init__(self, pos: TreePosition, stmt_list: List[StatementAst], imports_ast: ImportsAst):
+  def __init__(self, pos: TreePosition,
+               stmt_list: List[StatementAst],
+               imports_ast: ImportsAst,
+               file_path: Optional[Path] = None):
     super().__init__(pos)
     self.imports_ast = imports_ast
     self.stmt_list = stmt_list
+    self.file_path = file_path
 
   def children(self) -> List[AbstractSyntaxTree]:
     return [self.imports_ast] + self.stmt_list
@@ -304,7 +308,7 @@ class TranslationUnitAst(AbstractSyntaxTree):
 
   def make_module_ir_and_symbol_table(self, module_name: str,
                                       emit_debug: bool,
-                                      source_path: Optional[Path] = None) -> (ir.Module, SymbolTable):
+                                      main_file_path: Optional[Path] = None) -> (ir.Module, SymbolTable):
     assert self.check_pos_validity()
 
     module = ir.Module(name=module_name)
@@ -313,11 +317,12 @@ class TranslationUnitAst(AbstractSyntaxTree):
     symbol_table = SymbolTable()
     context = CodegenContext(
       builder=root_builder, module=module, emits_debug=emit_debug,
-      source_path=source_path)
+      source_path=main_file_path)
 
     build_initial_ir(symbol_table=symbol_table, context=context)
     assert context.ir_func_malloc is not None
     for ast in self.file_asts:
+      context.change_file(ast.file_path)
       for statement in ast.stmt_list:
         assert not context.is_terminated
         statement.build_ir(symbol_table=symbol_table, context=context)

--- a/sleepy/parse.py
+++ b/sleepy/parse.py
@@ -1,3 +1,5 @@
+from pathlib import Path
+
 from sleepy.ast import FileAst, TranslationUnitAst
 from sleepy.sleepy_lexer import SLEEPY_LEXER
 from sleepy.sleepy_parser import SLEEPY_ATTR_GRAMMAR, SLEEPY_PARSER
@@ -11,12 +13,12 @@ def make_program_ast(program: str) -> FileAst:
   return program_ast
 
 def make_preamble_ast() -> FileAst:
-  import os
-  preamble_path = os.path.join(os.path.dirname(os.path.abspath(__file__)), 'std/preamble.slp')
+  preamble_path = Path(__file__).parent.joinpath("std/preamble.slp").resolve()
   with open(preamble_path) as preamble_file:
     preamble_program = preamble_file.read()
-  return make_program_ast(preamble_program)
-
+  file_ast = make_program_ast(preamble_program)
+  file_ast.file_path = preamble_path
+  return file_ast
 
 def make_ast(program: str, add_preamble=True) -> TranslationUnitAst:
   file_asts = [make_preamble_ast()] if add_preamble else []

--- a/sleepy/sleepy_lexer.py
+++ b/sleepy/sleepy_lexer.py
@@ -10,6 +10,7 @@ TOKEN_INFO = [
   ('while', 'while', "KEYWORD"),
   ('ref', 'ref', "KEYWORD"),
   ('mutates', 'mutates', "KEYWORD"),
+  ('import', 'import', 'KEYWORD'),
   (':', ':', ''),
   ('{', '{', "BRACE"),
   ('}', '}', "BRACE"),

--- a/tests/compile.py
+++ b/tests/compile.py
@@ -10,12 +10,11 @@ from sleepy.symbols import FunctionSymbol
 def compile_program(engine: ExecutionEngine,
                     program: str,
                     main_func_identifier: str = 'main',
-                    debug: bool = True,
                     add_preamble: bool = True) -> Callable:
 
   ast = make_ast(program, add_preamble=add_preamble)
   module_ir, symbol_table = ast.make_module_ir_and_symbol_table(
-    module_name='test_parse_ast', emit_debug=debug)
+    module_name='test_parse_ast', emit_debug=False)
   print('---- module intermediate repr:')
   print(module_ir)
   optimized_module_ir = compile_ir(engine, module_ir)

--- a/tests/examples_cyclic_import/a.slp
+++ b/tests/examples_cyclic_import/a.slp
@@ -1,0 +1,3 @@
+import "cyclic/b.slp"
+
+func main() {}

--- a/tests/examples_cyclic_import/cyclic/b.slp
+++ b/tests/examples_cyclic_import/cyclic/b.slp
@@ -1,0 +1,1 @@
+import "c.slp"

--- a/tests/examples_cyclic_import/cyclic/c.slp
+++ b/tests/examples_cyclic_import/cyclic/c.slp
@@ -1,0 +1,1 @@
+import "d.slp"

--- a/tests/examples_cyclic_import/cyclic/d.slp
+++ b/tests/examples_cyclic_import/cyclic/d.slp
@@ -1,0 +1,1 @@
+import "b.slp"

--- a/tests/examples_import/chain/import_chain_2.slp
+++ b/tests/examples_import/chain/import_chain_2.slp
@@ -1,0 +1,3 @@
+import "import_chain_3.slp"
+struct C2 { v: Int; }
+func chain2() -> Int { return 1 + chain3() }

--- a/tests/examples_import/chain/import_chain_3.slp
+++ b/tests/examples_import/chain/import_chain_3.slp
@@ -1,0 +1,2 @@
+struct C3 { v: Int; }
+func chain3() -> Int { return 1 }

--- a/tests/examples_import/import_chain.slp
+++ b/tests/examples_import/import_chain.slp
@@ -1,0 +1,8 @@
+import "chain/import_chain_2.slp"
+
+func chain() -> Int { return 1 + chain2() }
+func main() -> Int {
+  c2 = C2(1)
+  c3 = C3(1)
+  return chain() + c2.v + c3.v
+}

--- a/tests/examples_import/import_up_and_down.slp
+++ b/tests/examples_import/import_up_and_down.slp
@@ -1,0 +1,3 @@
+import "up_and_down/down_1.slp"
+
+func main() -> Int { return down1() + down2() + down3() + upup() }

--- a/tests/examples_import/up_and_down/down/down/down_3.slp
+++ b/tests/examples_import/up_and_down/down/down/down_3.slp
@@ -1,0 +1,3 @@
+import "../../up_up.slp"
+
+func down3() -> Int { return 1 }

--- a/tests/examples_import/up_and_down/down/down_2.slp
+++ b/tests/examples_import/up_and_down/down/down_2.slp
@@ -1,0 +1,1 @@
+func down2() -> Int { return 1 }

--- a/tests/examples_import/up_and_down/down_1.slp
+++ b/tests/examples_import/up_and_down/down_1.slp
@@ -1,0 +1,3 @@
+import "down/down/down_3.slp", "down/down_2.slp"
+
+func down1() -> Int { return 1 }

--- a/tests/examples_import/up_and_down/up_up.slp
+++ b/tests/examples_import/up_and_down/up_up.slp
@@ -1,0 +1,1 @@
+func upup() -> Int { return 1 }

--- a/tests/run_examples_dir.py
+++ b/tests/run_examples_dir.py
@@ -16,7 +16,7 @@ def run_example(code_file_name=None):
     with open(code_file_name, 'r') as file:
       program = file.read()
     ast = make_ast(program)
-    module_ir, symbol_table = ast.make_module_ir_and_symbol_table(module_name='test_parse_ast', emit_debug=True)
+    module_ir, symbol_table = ast.make_module_ir_and_symbol_table(module_name='test_parse_ast', emit_debug=False)
     compile_ir(engine, module_ir)
     assert 'main' in symbol_table, 'Need to declare a main function'
     main_func_symbol = symbol_table['main']

--- a/tests/test_compile_examples.py
+++ b/tests/test_compile_examples.py
@@ -1,4 +1,8 @@
 import os
+from pathlib import Path
+from subprocess import CalledProcessError
+
+from nose.tools import assert_raises
 
 import _setup_test_env  # noqa
 
@@ -8,12 +12,29 @@ def _test_compile_example(code_file_name):
   exec_file_name = code_file_name[:-len('.slp')]
   print('\nCompiling and running example from %s.' % code_file_name)
   import subprocess
-  subprocess.run(['./tools/sleepy.py', code_file_name]).check_returncode()
+  sleepy_path = Path(__file__).parent.joinpath("../tools/sleepy.py").resolve()
+
+  subprocess.run([str(sleepy_path), code_file_name]).check_returncode()
   subprocess.run([exec_file_name])
 
 
+def _test_compile_example_failing(code_file_name):
+  with assert_raises(CalledProcessError):
+    _test_compile_example(code_file_name)
+
+from tests.run_examples_dir import find_all_example_files
+
 def test_compile_examples():
-  from tests.run_examples_dir import find_all_example_files
   code_file_root, code_file_names = find_all_example_files('examples')
   for code_file_name in code_file_names:
     yield _test_compile_example, os.path.join(code_file_root, code_file_name)
+
+def test_compile_examples_import():
+  code_file_root, code_file_names = find_all_example_files('examples_import')
+  for code_file_name in code_file_names:
+    yield _test_compile_example, os.path.join(code_file_root, code_file_name)
+
+def test_compile_examples_cyclic_import():
+  code_file_root, code_file_names = find_all_example_files('examples_cyclic_import')
+  for code_file_name in code_file_names:
+    yield _test_compile_example_failing, os.path.join(code_file_root, code_file_name)

--- a/tools/import_discovery.py
+++ b/tools/import_discovery.py
@@ -1,0 +1,50 @@
+from pathlib import Path
+from typing import List, Tuple
+
+import networkx as nx
+
+from sleepy.ast import FileAst
+from sleepy.parse import make_program_ast
+
+
+def make_ast_for_file(path: Path) -> FileAst:
+  with open(path) as program_file:
+    program = program_file.read()
+    ast = make_program_ast(program)
+    return ast
+
+
+def resolve_import_path(import_path: Path, importing_path: Path) -> Path:
+  if import_path.is_absolute(): return importing_path.resolve()
+  return importing_path.parent.joinpath(import_path).resolve()
+
+def process_file(path: Path, dag: nx.DiGraph) -> List[Path]:
+  current_ast = make_ast_for_file(path)
+  dag.nodes[path]["file_ast"] = current_ast
+
+  new_nodes = []
+
+  for child in current_ast.imports_ast.imports:
+    child = resolve_import_path(import_path=Path(child), importing_path=path)
+
+    if child not in dag.nodes:
+      dag.add_node(child, file_ast=None)
+      new_nodes.append(child)
+
+    dag.add_edge(path, child)
+
+  return new_nodes
+
+def build_file_dag(main_file: Path) -> Tuple[nx.DiGraph, Path]:
+  if not main_file.is_absolute(): main_file = Path.cwd().joinpath(main_file).resolve()
+
+  dag = nx.DiGraph()
+
+  dag.add_node(main_file, file_ast=None)
+  todo = process_file(main_file, dag)
+
+  while len(todo) > 0:
+    path = todo.pop()
+    todo += process_file(path, dag)
+
+  return dag, main_file

--- a/tools/import_discovery.py
+++ b/tools/import_discovery.py
@@ -12,6 +12,7 @@ def make_ast_for_file(path: Path) -> FileAst:
   with open(path) as program_file:
     program = program_file.read()
     ast = make_program_ast(program)
+    ast.file_path = path
     return ast
 
 

--- a/tools/import_discovery.py
+++ b/tools/import_discovery.py
@@ -4,6 +4,7 @@ from typing import List, Tuple
 import networkx as nx
 
 from sleepy.ast import FileAst
+from sleepy.errors import CompilerError
 from sleepy.parse import make_program_ast
 
 
@@ -48,3 +49,8 @@ def build_file_dag(main_file: Path) -> Tuple[nx.DiGraph, Path]:
     todo += process_file(path, dag)
 
   return dag, main_file
+
+def check_graph(graph: nx.DiGraph):
+  if not nx.is_directed_acyclic_graph(graph):
+    sccs = [ scc for scc in nx.strongly_connected_components(graph) if len(scc) > 1 ]
+    raise CompilerError(f"Import are cyclic. The following cycles were found:\n {sccs}")

--- a/tools/sleepy.py
+++ b/tools/sleepy.py
@@ -78,7 +78,7 @@ def main():
     print(file_dag.edges)
 
     module_ir, symbol_table = ast.make_module_ir_and_symbol_table(
-      module_name='default_module', emit_debug=args.debug, source_path=source_file_path)
+      module_name='default_module', emit_debug=args.debug, main_file_path=source_file_path)
     if main_func_identifier not in symbol_table:
       raise CompilerError('Error: Entry point function %r not found' % main_func_identifier)
     main_func_symbol = symbol_table[main_func_identifier]

--- a/tools/sleepy.py
+++ b/tools/sleepy.py
@@ -10,35 +10,32 @@ import better_exchook
 
 import _setup_sleepy_env  # noqa
 # noinspection PyUnresolvedReferences
+from sleepy.ast import FileAst, TranslationUnitAst
 from sleepy.errors import CompilerError
 # noinspection PyUnresolvedReferences
 from sleepy.jit import make_execution_engine, compile_ir, LIB_PATH
 # noinspection PyUnresolvedReferences
-from sleepy.parse import make_program_ast, make_ast
+from sleepy.parse import make_program_ast, make_ast, make_preamble_ast
 from sleepy.symbols import FunctionSymbol
 import llvmlite.binding as llvm
 
+from tools.import_discovery import build_file_dag
 
-def _make_file_name(source_file_name, file_ending, allow_exist=False):
+
+def _make_file_name(source_path: Path, file_ending: str, allow_exist=False) -> Path:
   """
-  :param str source_file_name:
   :param str file_ending: with leading . if applicable
-  :param bool allow_exist:
-  :rtype str:
   """
-  if source_file_name.endswith('.slp'):
-    base_file_name = source_file_name[:-len('.slp')]
-  else:
-    base_file_name = source_file_name
-    if file_ending == '':
-      base_file_name += '.out'
-  import os.path
-  if allow_exist or not os.path.isfile('%s%s' % (base_file_name, file_ending)):
-    return '%s%s' % (base_file_name, file_ending)
+  source_path = source_path.with_suffix(file_ending if file_ending != '' else '.out')
+
+  if allow_exist or not source_path.exists():
+    return source_path
   file_num = 0
-  while os.path.isfile('%s.%s%s' % (base_file_name, file_num, file_ending)):
+  source_path = source_path.with_stem(source_path.stem + str(file_num))
+  while source_path.exists():
     file_num += 1
-  return '%s.%s%s' % (base_file_name, file_num, file_ending)
+    source_path = source_path.with_stem(source_path.stem + str(file_num))
+  return source_path
 
 
 def main():
@@ -65,13 +62,19 @@ def main():
   args = parser.parse_args()
 
   main_func_identifier = 'main'
-  source_file_name: str = args.program
-  with open(source_file_name) as program_file:
-    program = program_file.read()
+  source_file_path: Path = Path(args.program)
   try:
-    ast = make_ast(program, add_preamble=not args.no_preamble)
+    file_dag, source_file_path = build_file_dag(source_file_path)
+
+    file_ast: FileAst = file_dag.nodes[source_file_path]["file_ast"]
+
+    ast = TranslationUnitAst.from_file_asts([make_preamble_ast(), file_ast])
+
+    print(file_dag.nodes)
+    print(file_dag.edges)
+
     module_ir, symbol_table = ast.make_module_ir_and_symbol_table(
-      module_name='default_module', emit_debug=args.debug, source_path=Path(source_file_name))
+      module_name='default_module', emit_debug=args.debug, source_path=source_file_path)
     if main_func_identifier not in symbol_table:
       raise CompilerError('Error: Entry point function %r not found' % main_func_identifier)
     main_func_symbol = symbol_table[main_func_identifier]
@@ -97,7 +100,7 @@ def main():
     print('\nExited with return value %r of type %r' % (return_val, concrete_main_func.return_type))
     return
 
-  object_file_name = _make_file_name(source_file_name, '.o', allow_exist=True)
+  object_file_name = _make_file_name(source_file_path, '.o', allow_exist=True)
   module_ref = llvm.parse_assembly(str(module_ir))
 
   print(f'Opt: {args.opt}')
@@ -111,7 +114,7 @@ def main():
     module_passes.run(module_ref)
 
   if args.emit_ir:
-    ir_file_name = _make_file_name(source_file_name, '.ll', allow_exist=True)
+    ir_file_name = _make_file_name(source_file_path, '.ll', allow_exist=True)
     with open(ir_file_name, 'w') as file:
       file.write(str(module_ir))
     return
@@ -123,7 +126,7 @@ def main():
   if args.emit_object:
     return
 
-  exec_file_name = _make_file_name(source_file_name, '', allow_exist=True)
+  exec_file_name = _make_file_name(source_file_path, '', allow_exist=True)
   import subprocess
   subprocess.run(
     ['gcc'] + (['-g'] if args.debug else []) + ['-o', exec_file_name, object_file_name, LIB_PATH + '_static.a']

--- a/tools/sleepy.py
+++ b/tools/sleepy.py
@@ -26,7 +26,10 @@ def _make_file_name(source_path: Path, file_ending: str, allow_exist=False) -> P
   """
   :param str file_ending: with leading . if applicable
   """
-  source_path = source_path.with_suffix(file_ending if file_ending != '' else '.out')
+  if source_path.suffix != ".slp":
+    file_ending = ".out" if file_ending == "" else file_ending
+
+  source_path = source_path.with_suffix(file_ending)
 
   if allow_exist or not source_path.exists():
     return source_path


### PR DESCRIPTION
Import with an optional import statement at the beginning of the file of the form `import "path" [, "paths"...]`. The paths may be absoulte or relative. Relative paths are resolved relative to the importing file. Cyclic imports are detected and reported.

Tests in our test suit are missing.