### PR TITLE
Fix debug info

### DIFF
--- a/sleepy/ast.py
+++ b/sleepy/ast.py
@@ -308,7 +308,7 @@ class TranslationUnitAst:
 
   def make_module_ir_and_symbol_table(self, module_name: str,
                                       emit_debug: bool,
-                                      main_file_path: Path | DummyPath = DummyPath("module")) -> (ir.Module, SymbolTable):  # noqa
+                                      main_file_path: Path | DummyPath = DummyPath("module")) -> (str, SymbolTable):  # noqa
     assert self.check_pos_validity()
 
     module = ir.Module(name=module_name, context=ir.Context())
@@ -324,7 +324,7 @@ class TranslationUnitAst:
     assert not context.is_terminated
     context.is_terminated = True
 
-    return module, symbol_table
+    return context.get_patched_ir() , symbol_table
 
   def check_pos_validity(self) -> bool:
     return all(child.check_pos_validity() for child in self.file_asts)

--- a/sleepy/jit.py
+++ b/sleepy/jit.py
@@ -33,14 +33,7 @@ def make_execution_engine():
   del engine
 
 
-def compile_ir(engine, llvm_ir):
-  """
-  :param ExecutionEngine engine:
-  :param str|Any llvm_ir:
-  :rtype: llvm.ModuleRef
-  """
-  if not isinstance(llvm_ir, str):
-    llvm_ir = llvm_ir.__repr__()
+def compile_ir(engine: ExecutionEngine, llvm_ir: str) -> llvm.ModuleRef:
   mod = llvm.parse_assembly(llvm_ir)
   mod.verify()
   engine.add_module(mod)

--- a/sleepy/symbols.py
+++ b/sleepy/symbols.py
@@ -823,7 +823,7 @@ class StructType(Type):
       di_derived_types.append(context.module.add_debug_info(
         'DIDerivedType', {
           'tag': ir.DIToken('DW_TAG_member'), 'baseType': member_type.make_di_type(context=context),
-          'name': member_identifier, 'size': member_type.size * 8, 'offset': getattr(self.c_val_type, member_identifier).offset * 8}))
+          'name': member_identifier, 'size': member_type.size * 8, 'offset': getattr(self.c_type, member_identifier).offset * 8}))
     return context.module.add_debug_info(
       'DICompositeType', {
         'name': repr(self), 'size': self.size * 8, 'tag': ir.DIToken('DW_TAG_structure_type'),
@@ -1876,7 +1876,7 @@ class CodegenContext:
   def _make_current_di_file(self, path: Path | DummyPath):
     assert self.emits_debug
     if isinstance(path, Path):
-      file_name, file_dir = path.name, path.parent
+      file_name, file_dir = path.name, str(path.parent)
     else:
       file_name, file_dir = path.dummy_name, ""
     return self.module.add_debug_info('DIFile', {'filename': file_name, 'directory': file_dir})

--- a/sleepy/symbols.py
+++ b/sleepy/symbols.py
@@ -5,7 +5,6 @@ from __future__ import annotations
 
 import copy
 import ctypes
-import typing
 from abc import ABC, abstractmethod
 from enum import Enum
 from pathlib import Path
@@ -758,7 +757,6 @@ class StructType(Type):
 
     if any(templ_type.has_templ_placeholder() for templ_type in templ_types):
       self.ir_val_type = None
-      self.c_val_type: Optional[typing.Type] = None
       super().__init__(templ_types=templ_types, ir_type=None, c_type=None, constructor=constructor)
     else:
       member_ir_types = [member_type.ir_type for member_type in member_types]

--- a/tests/compile.py
+++ b/tests/compile.py
@@ -11,11 +11,12 @@ from sleepy.symbols import FunctionSymbol
 def compile_program(engine: ExecutionEngine,
                     program: str,
                     main_func_identifier: str = 'main',
-                    add_preamble: bool = True) -> Callable:
+                    add_preamble: bool = True,
+                    emit_debug=True) -> Callable:
   file_path = DummyPath("test")
   ast = make_translation_unit_ast_from_str(file_path=file_path, program=program, add_preamble=add_preamble)
   module_ir, symbol_table = ast.make_module_ir_and_symbol_table(
-    module_name='test_parse_ast', emit_debug=False)
+    module_name='test_parse_ast', emit_debug=emit_debug)
   print('---- module intermediate repr:')
   print(module_ir)
   optimized_module_ir = compile_ir(engine, module_ir)

--- a/tests/test_ast.py
+++ b/tests/test_ast.py
@@ -590,8 +590,9 @@ def test_struct_self_referencing_member():
       a = LinkedList(41, !b);
     }
     """
-    main = compile_program(engine, program, add_preamble=False)
+    main = compile_program(engine, program, add_preamble=False, emit_debug=False)
     main()
+    assert False, "Should work with emit_debug=True but infinitely recurses"
 
 
 def test_if_missing_return_branch():

--- a/tests/test_ast.py
+++ b/tests/test_ast.py
@@ -590,9 +590,8 @@ def test_struct_self_referencing_member():
       a = LinkedList(41, !b);
     }
     """
-    main = compile_program(engine, program, add_preamble=False, emit_debug=False)
+    main = compile_program(engine, program, add_preamble=False)
     main()
-    assert False, "Should work with emit_debug=True but infinitely recurses"
 
 
 def test_if_missing_return_branch():


### PR DESCRIPTION
Debug info does not crash any more and also works for self referential structs. Still needs to be fixed for unions.