### PR TITLE
Return empty struct everywhere instead of void

### DIFF
--- a/sleepy/symbols.py
+++ b/sleepy/symbols.py
@@ -135,7 +135,7 @@ class UnitType(Type):
   """
 
   def __init__(self):
-    super().__init__(templ_types=[], ir_type=ir.types.LiteralStructType(()), c_type=type("Unit", (ctypes.Structure,), {}), constructor=None)
+    super().__init__(templ_types=[], ir_type=ir.types.LiteralStructType(()), c_type=ctypes.c_char * 0, constructor=None)
 
   def __repr__(self) -> str:
     return 'Unit'

--- a/tests/compile.py
+++ b/tests/compile.py
@@ -19,9 +19,7 @@ def compile_program(engine: ExecutionEngine,
     module_name='test_parse_ast', emit_debug=emit_debug)
   print('---- module intermediate repr:')
   print(module_ir)
-  optimized_module_ir = compile_ir(engine, module_ir)
-  print('---- optimized module intermediate repr:')
-  print(optimized_module_ir)
+  compile_ir(engine, module_ir)
   assert main_func_identifier in symbol_table
   main_func_symbol = symbol_table[main_func_identifier]
   assert isinstance(main_func_symbol, FunctionSymbol)

--- a/tests/test_ast.py
+++ b/tests/test_ast.py
@@ -976,31 +976,28 @@ def test_if_inside_while2():
     assert_equal(main(0), 7)
 
 
-def test_wrong_assign_void():
+def test_assign_unit():
   with make_execution_engine() as engine:
     # language=Sleepy
     program = """
     func nothing()  { }
     func main()  {
-      x = nothing()  # cannot assign void to x.
+      x = nothing()
     }
     """
-    with assert_raises(SemanticError):
-      compile_program(engine, program)
+    compile_program(engine, program)
 
 
-def test_wrong_return_void():
+def test_return_unit_expression():
   with make_execution_engine() as engine:
     # language=Sleepy
     program = """
     func nothing()  { }
     func main()  {
-      return nothing()  # cannot return void.
+      return nothing()  # should work
     }
     """
-    with assert_raises(SemanticError):
-      compile_program(engine, program)
-
+    compile_program(engine, program, add_preamble=False)
 
 def test_func_operator():
   with make_execution_engine() as engine:
@@ -2610,5 +2607,22 @@ def test_no_semicolon_one_line_struct():
     # language=Sleepy
     program = """
       func main() { struct S { i: Int } }
+    """
+    compile_program(engine, program, add_preamble=False)
+
+def test_unit_in_union():
+  with make_execution_engine() as engine:
+    # language=Sleepy
+    program = """
+      func U() { }
+      func main() -> Int {
+        u: Unit|Int = U()
+        while(1 == 2) {}
+        if u is Unit {
+          return 42
+        } else {
+          return u
+        }
+      }
     """
     compile_program(engine, program, add_preamble=False)

--- a/tests/test_ast.py
+++ b/tests/test_ast.py
@@ -7,6 +7,7 @@ import _setup_test_env  # noqa
 from sleepy.errors import SemanticError, ParseError
 from sleepy.grammar import DummyPath
 from sleepy.jit import make_execution_engine
+from sleepy.symbols import SLEEPY_UNIT
 from tests.compile import compile_program
 from sleepy.parse import make_translation_unit_ast_from_str, make_file_ast_from_str
 
@@ -88,8 +89,7 @@ def test_empty_func():
     }
     """
     nothing = compile_program(engine, program, add_preamble=False)
-    assert_equal(nothing(), None)
-
+    assert_equal(type(nothing()), SLEEPY_UNIT.c_type)
 
 def test_empty_func_with_preamble():
   with make_execution_engine() as engine:
@@ -99,7 +99,7 @@ def test_empty_func_with_preamble():
     }
     """
     nothing = compile_program(engine, program, add_preamble=True)
-    assert_equal(nothing(), None)
+    assert_equal(type(nothing()), SLEEPY_UNIT.c_type)
 
 
 def test_empty_func_with_arg():
@@ -110,7 +110,7 @@ def test_empty_func_with_arg():
     }
     """
     nothing = compile_program(engine, program, add_preamble=False)
-    assert_equal(nothing(2), None)
+    assert_equal(type(nothing(5)), SLEEPY_UNIT.c_type)
 
 
 def test_lerp():


### PR DESCRIPTION
To gain back the same efficiency as with void, we could implement an optimization that returns void instead of any zero-size type and creates an llvm constant of that type at the call site.