### PR TITLE
Refactor union type

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -2,5 +2,6 @@ better_exchook
 nose~=1.3.7
 numpy
 llvmlite~=0.36.0
+frozendict~=2.3.0
 
 networkx~=2.6.3

--- a/sleepy/types.py
+++ b/sleepy/types.py
@@ -463,8 +463,7 @@ class UnionType(Type):
       assert val_size is not None
       assert all(val_size >= possible_type.size for possible_type in self.possible_types)
       self.untagged_union_ir_type = ir.types.ArrayType(ir.types.IntType(8), val_size)
-      self.untagged_union_c_type = ctypes.c_ubyte * max(
-        (ctypes.sizeof(possible_type.c_type) for possible_type in self.possible_types), default=0)
+      self.untagged_union_c_type = ctypes.c_ubyte * val_size
       c_type = type(
         '%s_CType' % self.identifier, (ctypes.Structure,),
         {'_fields_': [('tag', self.tag_c_type), ('untagged_union', self.untagged_union_c_type)]})

--- a/sleepy/types.py
+++ b/sleepy/types.py
@@ -621,8 +621,9 @@ class UnionType(Type):
       val_size=self.val_size)
 
   def copy_with_extended_variant_index_map(self, added_variant_index_map: Mapping[Type, int]):
-
-    new_variant_index_map = added_variant_index_map | self.variant_index_map  # values from rhs are preferred
+    new_variant_index_map = dict(self.variant_index_map)
+    for new_variant in added_variant_index_map.keys() - self.variant_index_map.keys():
+      new_variant_index_map[new_variant] = UnionType._first_unused_index(new_variant_index_map.values())
 
     return UnionType(
       type_index_map=new_variant_index_map,

--- a/sleepy/types.py
+++ b/sleepy/types.py
@@ -640,7 +640,7 @@ class UnionType(Type):
 
   @staticmethod
   def from_types(possible_types: Collection[Type], val_size: Optional[int] = None) -> UnionType:
-    possible_types = set(possible_types)
+    possible_types = list(dict.fromkeys(possible_types)) # python-y way to remove duplicates while preserving order
     if val_size is None: val_size = UnionType._new_val_size(possible_types)
 
     return UnionType(type_mapping=frozendict(zip(possible_types, range(len(possible_types)))), val_size=val_size)


### PR DESCRIPTION
Refactor UnionType to use a mapping from types to ints instead of two parallel lists.